### PR TITLE
Pin nginx to 1.11

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:1.11
 ADD ./st2.conf /etc/nginx/conf.d/st2.conf
 
 ADD ./st2*.deb /tmp/


### PR DESCRIPTION
nginx containers started changing to not install the `ca-certificates` package, which in turn means `openssl` is not available. We use that to generate ST2 self-signed certificates for testing.

This change pins the nginx container version.

Addresses https://github.com/StackStorm/st2box/issues/7